### PR TITLE
Fix https

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,22 +1,43 @@
 PATH
   remote: .
   specs:
-    google_directions (0.1.6.3)
-      nokogiri (>= 1.4.1)
+    google_directions (1.6.6.2)
+      nokogiri (~> 1.6)
 
 GEM
   remote: https://rubygems.org/
   specs:
+    allison (2.0.3)
+    echoe (4.6.6)
+      allison (>= 2.0.3)
+      rake (>= 0.9.2)
+      rdoc (>= 2.5.11)
+      rubyforge (>= 2.0.4)
+    json (1.8.3)
+    json_pure (1.8.2)
     metaclass (0.0.4)
-    mini_portile (0.6.0)
+    mini_portile (0.6.2)
+    minitest (5.8.0)
     mocha (1.1.0)
       metaclass (~> 0.0.1)
-    nokogiri (1.6.3.1)
-      mini_portile (= 0.6.0)
+    nokogiri (1.6.6.2)
+      mini_portile (~> 0.6.0)
+    rake (10.4.2)
+    rdoc (4.2.0)
+      json (~> 1.4)
+    rubyforge (2.0.4)
+      json_pure (>= 1.1.7)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
+  bundler (~> 1.10)
+  echoe (~> 4.6)
   google_directions!
-  mocha
+  minitest
+  mocha (~> 1.1, >= 1.1.0)
+  rake (~> 10.0)
+
+BUNDLED WITH
+   1.10.6

--- a/google_directions.gemspec
+++ b/google_directions.gemspec
@@ -1,20 +1,25 @@
 # coding: utf-8
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'google_directions'
+require 'google_directions_version'
 
 Gem::Specification.new do |s|
   s.name        = 'google_directions'
-  s.version     = GoogleDirections::VERSION
+  s.version     = GoogleDirectionsVersion::VERSION
   s.summary     = "Ruby-wrapper for Google Directions API"
   s.description = "Ruby-wrapper for Google Directions API. Can return the drive time and driving distance between two places."
   s.authors     = ["Josh Crews"]
   s.email       = 'josh@joshcrews.com'
-  s.files       = `git ls-files -z`.split("\x0") 
+  s.files       = `git ls-files -z`.split("\x0")
   s.test_files  = s.files.grep(%r{^(test|spec|features)/})
   s.homepage    = 'https://github.com/joshcrews/google-directions-ruby'
   s.license     = 'MIT'
 
-  s.add_dependency 'nokogiri', '~> 1.4', '>= 1.4.1'
+  s.add_dependency 'nokogiri', '~> 1.6'
   s.add_development_dependency 'mocha', '~>1.1', '>= 1.1.0'
+  s.add_development_dependency "bundler", "~> 1.10"
+  s.add_development_dependency "rake", "~> 10.0"
+  s.add_development_dependency "minitest"
+  s.add_development_dependency "echoe", "~> 4.6"
+
 end

--- a/lib/google_directions.rb
+++ b/lib/google_directions.rb
@@ -20,20 +20,21 @@ class GoogleDirections
   attr_reader :status, :doc, :xml, :origin, :destination, :options
 
   def initialize(origin, destination, opts=DEFAULT_OPTIONS)
-    @origin = origin
+    @origin      = origin
     @destination = destination
-    @options = opts.merge({:origin => @origin, :destination => @destination})
-    path = BASE_PATH + '?' + querify(@options)
-    @url = BASE_URL + sign_path(path, @options)
-    @xml = open(@url).read
-    @doc = Nokogiri::XML(@xml)
-    @status = @doc.css('status').text
+    @options     = opts.merge({:origin => @origin, :destination => @destination})
+    path         = BASE_PATH + '?' + querify(@options)
+    @url         = BASE_URL + sign_path(path, @options)
+    @xml         = open(@url).read
+    @doc         = Nokogiri::XML(@xml)
+    @status      = @doc.css('status').text
   end
 
   def xml_call
     @url
   end
 
+  # returns the drive time in minutes. returns 0 if the request was unsuccessful
   def drive_time_in_minutes
     unless successful?
       drive_time = 0

--- a/lib/google_directions.rb
+++ b/lib/google_directions.rb
@@ -63,6 +63,7 @@ class GoogleDirections
     end
   end
 
+  # returns the distance in miles between the origin and the destination.
   def distance_in_miles
     unless successful?
       distance_in_miles = 0
@@ -73,6 +74,7 @@ class GoogleDirections
     end
   end
 
+  # returns true if the status is successful
   def successful?
     @status == "OK"
   end

--- a/lib/google_directions.rb
+++ b/lib/google_directions.rb
@@ -8,7 +8,7 @@ require 'base64'
 
 class GoogleDirections
   VERSION   = '0.1.6.3'
-  BASE_URL  = 'http://maps.googleapis.com'
+  BASE_URL  = 'https://maps.googleapis.com'
   BASE_PATH = '/maps/api/directions/xml'
   DEFAULT_OPTIONS = {
     :language => :en,

--- a/lib/google_directions_version.rb
+++ b/lib/google_directions_version.rb
@@ -1,0 +1,3 @@
+class GoogleDirectionsVersion
+  VERSION = "1.6.6.2"
+end

--- a/test/unit/google_directions_test.rb
+++ b/test/unit/google_directions_test.rb
@@ -12,7 +12,7 @@ class GoogleDirectionsTest < Minitest::Test
     assert_equal(4, directions.distance_in_miles)
     assert_equal(5, directions.drive_time_in_minutes)
     assert_equal(directions.successful?, true)
-    assert_equal('http://maps.googleapis.com/maps/api/directions/xml?language=en&alternative=true&sensor=false&mode=driving&origin=121+Gordonsville+Highway%2C+37030&destination=499+Gordonsville+Highway%2C+38563', directions.xml_call)
+    assert_equal('https://maps.googleapis.com/maps/api/directions/xml?language=en&alternative=true&sensor=false&mode=driving&origin=121+Gordonsville+Highway%2C+37030&destination=499+Gordonsville+Highway%2C+38563', directions.xml_call)
     # end_location > lat
 
     assert_equal orig, directions.origin


### PR DESCRIPTION
Apparently google now needs requests to be done to the `https` url.

I wasn't able to run the tests. Maybe we can enhance the documentation? Also I noticed that we should move all into modules. I did a dirty hack with the `VERSION`. I couldn't require the file because that would have required `nokogiri` which was required at a later stage.